### PR TITLE
Add endpoint to update subject status based on school year status

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2136,7 +2136,7 @@ app.get('/subjects', (req, res) => {
   const { searchTerm, school_year, grade, archive_status } = req.query;
   
   let query = `
-    SELECT s.subject_id, s.grade_level, s.subject_name, s.status, s.grading_criteria, s.description, s.archive_status, sy.school_year_id, sy.status
+    SELECT s.subject_id, s.grade_level, s.subject_name, s.status, s.grading_criteria, s.description, s.archive_status, sy.school_year_id
     FROM subject s  
     JOIN school_year sy ON s.school_year_id = sy.school_year_id
     WHERE s.archive_status = ? order by s.grade_level DESC
@@ -2163,6 +2163,23 @@ app.get('/subjects', (req, res) => {
       return res.status(500).send(error);
     }
     res.send(results);
+  });
+});
+
+app.put('/update-subjects-status', (req, res) => {
+  const query = `
+    UPDATE subject 
+    SET status = 'inactive' 
+    WHERE school_year_id IN (
+      SELECT school_year_id FROM school_year WHERE status = 'inactive'
+    )
+  `;
+
+  db.query(query, (error, results) => {
+    if (error) {
+      return res.status(500).send(error);
+    }
+    res.send({ message: 'Subjects updated successfully', affectedRows: results.affectedRows });
   });
 });
 

--- a/src/PrincipalPages/Principal_SubjectsPage.js
+++ b/src/PrincipalPages/Principal_SubjectsPage.js
@@ -27,10 +27,13 @@ function Principal_SubjectsPage() {
 
   const fetchSubjects = useCallback(async () => {
     try {
-      const response = await axios.get('http://localhost:3001/subjects', {
-        params: filters,
-      });
+      // Ensure subjects are updated if the school year is inactive
+      await axios.put('http://localhost:3001/update-subjects-status');
+  
+      // Fetch subjects after updating
+      const response = await axios.get('http://localhost:3001/subjects', { params: filters });
       setSubjects(response.data);
+  
       if (selectedGrade) {
         setFilteredSubjects(
           response.data.filter((subject) => String(subject.grade_level) === String(selectedGrade))
@@ -42,7 +45,7 @@ function Principal_SubjectsPage() {
       console.error('Error fetching subjects:', error);
     }
   }, [filters, selectedGrade]);
-
+  
   useEffect(() => {
     fetchSubjects();
   }, [fetchSubjects]);
@@ -197,7 +200,7 @@ function Principal_SubjectsPage() {
                         <button 
                           className="delete-button" 
                           onClick={handleDelete} 
-                          disabled={selectedSubject?.status === 'active'} // Disable if status is not 'active'
+                          disabled={selectedSubject?.sy_status === 'active'} // Disable if status is not 'active'
                         >
                           Archive
                         </button>


### PR DESCRIPTION
- Implement backend route to automatically set subjects to inactive when their associated school year is inactive
- Modify frontend to call new update-subjects-status endpoint before fetching subjects
- Remove unnecessary school_year column from subjects query
- Update archiving button disable condition to use school year status