### PR TITLE
Refactor CSS Class Names for Form 137 and Form 138

### DIFF
--- a/src/CssFiles/form_137.css
+++ b/src/CssFiles/form_137.css
@@ -1,6 +1,6 @@
 /* Form 137 - Permanent Record CSS */
 
-.form-137-container {
+.f137-container {
   max-width: 950px;
   margin: 0 auto;
   padding: 15px;
@@ -10,7 +10,7 @@
   font-size: 12px;
 }
 
-.form-header {
+.f137-header {
   text-align: center;
   margin-bottom: 8px;
   border-bottom: 1px solid #000;
@@ -20,43 +20,43 @@
   justify-content: space-between;
 }
 
-.form-header-text {
+.f137-header-text {
   flex: 1;
   padding: 0 10px;
 }
 
-.form-header h1, .form-header h2, .form-header h3 {
+.f137-header h1, .f137-header h2, .f137-header h3 {
   font-size: 14px;
   margin: 2px 0;
   font-weight: normal;
 }
 
-.form-header h1 {
+.f137-header h1 {
   text-transform: uppercase;
   font-weight: bold;
 }
 
-.form-header h2:nth-of-type(2) {
+.f137-header h2:nth-of-type(2) {
   font-weight: bold;
 }
 
-.form-header h3:last-child {
+.f137-header h3:last-child {
   font-weight: bold;
 }
 
-.form-header-logos {
+.f137-header-logos {
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
-.logo {
+.f137-logo {
   width: 65px;
   height: auto;
   margin: 0 5px;
 }
 
-.student-info {
+.f137-student-info {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 8px;
@@ -66,25 +66,25 @@
   background-color: #f9f9f9;
 }
 
-.info-item {
+.f137-info-item {
   margin-bottom: 5px;
   display: flex;
   align-items: center;
 }
 
-.info-label {
+.f137-info-label {
   font-weight: bold;
   margin-right: 3px;
 }
 
-.academic-records {
+.f137-academic-records {
   margin-bottom: 15px;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
 }
 
-.school-year-section {
+.f137-school-year-section {
   width: 49%;
   margin-bottom: 10px;
   border: 1px solid #ddd;
@@ -93,7 +93,7 @@
   font-size: 10px;
 }
 
-.school-year-header {
+.f137-school-year-header {
   background-color: #f0f0f0;
   padding: 3px;
   margin-bottom: 5px;
@@ -102,68 +102,68 @@
   font-size: 10px;
 }
 
-.grades-table {
+.f137-grades-table {
   width: 100%;
   border-collapse: collapse;
   border: 1px solid #ddd;
   margin-bottom: 20px;
 }
 
-.grades-table th, 
-.grades-table td {
+.f137-grades-table th, 
+.f137-grades-table td {
   border: 1px solid #ddd;
   padding: 8px;
   text-align: center;
 }
 
-.grades-table th {
+.f137-grades-table th {
   background-color: #f0f0f0;
   font-weight: bold;
 }
 
-.grades-table tr:nth-child(even) {
+.f137-grades-table tr:nth-child(even) {
   background-color: #f9f9f9;
 }
 
-.grades-table .subject-name {
+.f137-grades-table .f137-subject-name {
   text-align: left;
   font-weight: bold;
 }
 
-.attendance-section {
+.f137-attendance-section {
   margin-top: 5px;
 }
 
-.attendance-section h3 {
+.f137-attendance-section h3 {
   font-size: 14px;
   margin: 5px 0;
 }
 
-.attendance-table {
+.f137-attendance-table {
   width: 100%;
   border-collapse: collapse;
   border: 1px solid #ddd;
   margin-bottom: 20px;
 }
 
-.attendance-table th, 
-.attendance-table td {
+.f137-attendance-table th, 
+.f137-attendance-table td {
   border: 1px solid #ddd;
   padding: 8px;
   text-align: center;
   font-size: 12px;
 }
 
-.attendance-table th {
+.f137-attendance-table th {
   background-color: #f0f0f0;
   font-weight: bold;
 }
 
-.attendance-table tr:nth-child(even) {
+.f137-attendance-table tr:nth-child(even) {
   background-color: #f9f9f9;
 }
 
-.summary-section {
+.f137-summary-section {
   margin-top: 5px;
   font-size: 10px;
   display: flex;
@@ -172,7 +172,7 @@
   height: 100%;
 }
 
-.certification-section {
+.f137-certification-section {
   margin-top: 10px;
   padding: 8px;
   border: 1px solid #ddd;
@@ -180,31 +180,31 @@
   font-size: 11px;
 }
 
-.signature-section {
+.f137-signature-section {
   display: flex;
   justify-content: space-between;
   margin-top: 20px;
 }
 
-.signature-box {
+.f137-signature-box {
   text-align: center;
   width: 150px;
 }
 
-.signature-line {
+.f137-signature-line {
   border-top: 1px solid #000;
   margin-top: 20px;
   padding-top: 3px;
 }
 
-.button-container {
+.f137-button-container {
   display: flex;
   justify-content: center;
   gap: 15px;
   margin-top: 15px;
 }
 
-.button-container button {
+.f137-button-container button {
   padding: 8px 15px;
   background-color: #4CAF50;
   color: white;
@@ -214,24 +214,24 @@
   font-size: 14px;
 }
 
-.button-container button:hover {
+.f137-button-container button:hover {
   background-color: #45a049;
 }
 
-.button-container button:first-child {
+.f137-button-container button:first-child {
   background-color: #f44336;
 }
 
-.button-container button:first-child:hover {
+.f137-button-container button:first-child:hover {
   background-color: #d32f2f;
 }
 
 @media print {
-  .button-container {
+  .f137-button-container {
     display: none !important;
   }
 
-  .form-137-container {
+  .f137-container {
     padding: 10px;
     max-width: 100%;
     margin: 0;
@@ -239,36 +239,36 @@
     font-size: 10px;
   }
 
-  .school-year-section {
+  .f137-school-year-section {
     width: 49%;
     margin-bottom: 5px;
     padding: 3px;
     page-break-inside: avoid;
   }
 
-  .academic-grades-table, 
-  .student-attendance-table {
+  .f137-academic-grades-table, 
+  .f137-student-attendance-table {
     font-size: 9px;
   }
 
-  .academic-grades-table th, 
-  .academic-grades-table td,
-  .student-attendance-table th, 
-  .student-attendance-table td {
+  .f137-academic-grades-table th, 
+  .f137-academic-grades-table td,
+  .f137-student-attendance-table th, 
+  .f137-student-attendance-table td {
     padding: 1px;
   }
 
-  .form-header {
+  .f137-header {
     margin-bottom: 5px;
   }
 
-  .student-info {
+  .f137-student-info {
     margin-bottom: 5px;
   }
 }
 
 /* Academic grades table - completely separate styling */
-.academic-grades-table {
+.f137-academic-grades-table {
   width: 100%;
   border-collapse: collapse;
   border: 1px solid #ddd;
@@ -276,34 +276,34 @@
   font-size: 10px;
 }
 
-.academic-grades-table th, 
-.academic-grades-table td {
+.f137-academic-grades-table th, 
+.f137-academic-grades-table td {
   border: 1px solid #ddd;
   padding: 2px;
   text-align: center;
 }
 
-.academic-grades-table th {
+.f137-academic-grades-table th {
   background-color: #f0f0f0;
   font-weight: bold;
 }
 
-.academic-grades-table tr:nth-child(even) {
+.f137-academic-grades-table tr:nth-child(even) {
   background-color: #f9f9f9;
 }
 
-.academic-grades-table .subject-name {
+.f137-academic-grades-table .f137-subject-name {
   text-align: left;
   font-weight: bold;
   padding-left: 3px;
 }
 
-.academic-grades-table .final-grade {
+.f137-academic-grades-table .f137-final-grade {
   font-weight: bold;
 }
 
 /* Student attendance table - completely separate styling */
-.student-attendance-table {
+.f137-student-attendance-table {
   width: 100%;
   border-collapse: collapse;
   border: 1px solid #ddd;
@@ -311,18 +311,18 @@
   font-size: 10px;
 }
 
-.student-attendance-table th, 
-.student-attendance-table td {
+.f137-student-attendance-table th, 
+.f137-student-attendance-table td {
   border: 1px solid #ddd;
   padding: 2px;
   text-align: center;
 }
 
-.student-attendance-table th {
+.f137-student-attendance-table th {
   background-color: #f0f0f0;
   font-weight: bold;
 }
 
-.student-attendance-table tr:nth-child(even) {
+.f137-student-attendance-table tr:nth-child(even) {
   background-color: #f9f9f9;
 }

--- a/src/CssFiles/form_138.css
+++ b/src/CssFiles/form_138.css
@@ -1,6 +1,6 @@
 /* Form 138 - Current Grade Level Record CSS */
 
-.form-138-container {
+.f138-container {
   max-width: 850px;
   margin: 0 auto;
   padding: 15px;
@@ -10,7 +10,7 @@
   font-size: 12px;
 }
 
-.form-header {
+.f138-header {
   text-align: center;
   margin-bottom: 8px;
   border-bottom: 1px solid #000;
@@ -20,43 +20,43 @@
   justify-content: space-between;
 }
 
-.form-header-text {
+.f138-header-text {
   flex: 1;
   padding: 0 10px;
 }
 
-.form-header h1, .form-header h2, .form-header h3 {
+.f138-header h1, .f138-header h2, .f138-header h3 {
   font-size: 14px;
   margin: 2px 0;
   font-weight: normal;
 }
 
-.form-header h1 {
+.f138-header h1 {
   text-transform: uppercase;
   font-weight: bold;
 }
 
-.form-header h2:nth-of-type(2) {
+.f138-header h2:nth-of-type(2) {
   font-weight: bold;
 }
 
-.form-header h3:last-child {
+.f138-header h3:last-child {
   font-weight: bold;
 }
 
-.form-header-logos {
+.f138-header-logos {
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
-.logo {
+.f138-logo {
   width: 65px;
   height: auto;
   margin: 0 5px;
 }
 
-.student-info {
+.f138-student-info {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 8px;
@@ -66,127 +66,128 @@
   background-color: #f9f9f9;
 }
 
-.info-item {
+.f138-info-item {
   margin-bottom: 5px;
 }
 
-.info-label {
+.f138-info-label {
   font-weight: bold;
   margin-right: 3px;
 }
 
-.grades-section {
+.f138-grades-section {
   margin-bottom: 15px;
 }
 
-.grades-section h3 {
+.f138-grades-section h3 {
   font-size: 14px;
   margin: 5px 0;
 }
 
 /* Simple table styles */
-.grades-table {
+.f138-grades-table {
   width: 100%;
   border-collapse: collapse;
   border: 1px solid #ddd;
   margin-bottom: 20px;
 }
 
-.grades-table th, 
-.grades-table td {
+.f138-grades-table th, 
+.f138-grades-table td {
   border: 1px solid #ddd;
   padding: 8px;
   text-align: center;
 }
 
-.grades-table th {
+.f138-grades-table th {
   background-color: #f0f0f0;
   font-weight: bold;
 }
 
-.grades-table tr:nth-child(even) {
+.f138-grades-table tr:nth-child(even) {
   background-color: #f9f9f9;
 }
 
-.grades-table .subject-name {
+.f138-grades-table .f138-subject-name {
   text-align: left;
   font-weight: bold;
 }
 
-.grades-table .final-grade {
+.f138-grades-table .f138-final-grade {
   font-weight: bold;
 }
 
-.attendance-section {
+.f138-attendance-section {
   margin-top: 10px;
 }
 
-.attendance-section h3 {
+.f138-attendance-section h3 {
   font-size: 14px;
   margin: 5px 0;
 }
 
-.attendance-table {
+.f138-attendance-table {
   width: 100%;
   border-collapse: collapse;
   border: 1px solid #ddd;
   margin-bottom: 20px;
 }
 
-.attendance-table th, 
-.attendance-table td {
+.f138-attendance-table th, 
+.f138-attendance-table td {
   border: 1px solid #ddd;
   padding: 8px;
   text-align: center;
+  font-size: 12px;
 }
 
-.attendance-table th {
+.f138-attendance-table th {
   background-color: #f0f0f0;
   font-weight: bold;
   background-color: #28a745;
 }
 
-.attendance-table tr:nth-child(even) {
+.f138-attendance-table tr:nth-child(even) {
   background-color: #f9f9f9;
 }
 
-.promotion-section {
+.f138-promotion-section {
   margin-top: 10px;
   padding: 8px;
   border: 1px solid #ddd;
   font-size: 11px;
 }
 
-.promotion-section h3 {
+.f138-promotion-section h3 {
   font-size: 14px;
   margin: 5px 0;
 }
 
-.signature-section {
+.f138-signature-section {
   display: flex;
   justify-content: space-between;
   margin-top: 20px;
 }
 
-.signature-box {
+.f138-signature-box {
   text-align: center;
   width: 150px;
 }
 
-.signature-line {
+.f138-signature-line {
   border-top: 1px solid #000;
   margin-top: 20px;
   padding-top: 3px;
 }
 
-.button-container {
+.f138-button-container {
   display: flex;
   justify-content: center;
   gap: 15px;
   margin-top: 15px;
 }
 
-.button-container button {
+.f138-button-container button {
   padding: 8px 15px;
   background-color: #4CAF50;
   color: white;
@@ -196,24 +197,24 @@
   font-size: 14px;
 }
 
-.button-container button:hover {
+.f138-button-container button:hover {
   background-color: #45a049;
 }
 
-.button-container button:first-child {
+.f138-button-container button:first-child {
   background-color: #f44336;
 }
 
-.button-container button:first-child:hover {
+.f138-button-container button:first-child:hover {
   background-color: #d32f2f;
 }
 
 @media print {
-  .button-container {
+  .f138-button-container {
     display: none;
   }
   
-  .form-138-container {
+  .f138-container {
     box-shadow: none;
     margin: 0;
     padding: 0;
@@ -221,61 +222,61 @@
 }
 
 /* Academic grades table - completely separate styling */
-.academic-grades-table {
+.f138-academic-grades-table {
   width: 100%;
   border-collapse: collapse;
   border: 1px solid #ddd;
   margin-bottom: 10px;
 }
 
-.academic-grades-table th, 
-.academic-grades-table td {
+.f138-academic-grades-table th, 
+.f138-academic-grades-table td {
   border: 1px solid #ddd;
   padding: 4px;
   text-align: center;
   font-size: 11px;
 }
 
-.academic-grades-table th {
+.f138-academic-grades-table th {
   background-color: #f0f0f0;
   font-weight: bold;
 }
 
-.academic-grades-table tr:nth-child(even) {
+.f138-academic-grades-table tr:nth-child(even) {
   background-color: #f9f9f9;
 }
 
-.academic-grades-table .subject-name {
+.f138-academic-grades-table .f138-subject-name {
   text-align: left;
   font-weight: bold;
 }
 
-.academic-grades-table .final-grade {
+.f138-academic-grades-table .f138-final-grade {
   font-weight: bold;
 }
 
 /* Student attendance table - completely separate styling */
-.student-attendance-table {
+.f138-student-attendance-table {
   width: 100%;
   border-collapse: collapse;
   border: 1px solid #ddd;
   margin-bottom: 10px;
 }
 
-.student-attendance-table th, 
-.student-attendance-table td {
+.f138-student-attendance-table th, 
+.f138-student-attendance-table td {
   border: 1px solid #ddd;
   padding: 3px;
   text-align: center;
   font-size: 10px;
 }
 
-.student-attendance-table th {
+.f138-student-attendance-table th {
   background-color: #f0f0f0;
   font-weight: bold;
   background-color: #28a745;
 }
 
-.student-attendance-table tr:nth-child(even) {
+.f138-student-attendance-table tr:nth-child(even) {
   background-color: #f9f9f9;
 } 

--- a/src/reports/form_137.js
+++ b/src/reports/form_137.js
@@ -162,10 +162,10 @@ function Form137() {
       format: "a4",
     });
 
-    const button = document.querySelector(".button-container");
+    const button = document.querySelector(".f137-button-container");
     if (button) button.style.display = "none";
 
-    doc.html(document.querySelector(".form-137-container"), {
+    doc.html(document.querySelector(".f137-container"), {
       callback: function (doc) {
         window.open(doc.output("bloburl"), "_blank");
         if (button) button.style.display = "flex";
@@ -191,50 +191,50 @@ function Form137() {
 
   return (
     <div>
-      <div className="form-137-container">
-        <div className="form-header">
-          <div className="form-header-logos">
-            <img src="/deped-logo.png" alt="DepEd Logo" className="logo" />
+      <div className="f137-container">
+        <div className="f137-header">
+          <div className="f137-header-logos">
+            <img src="/deped-logo.png" alt="DepEd Logo" className="f137-logo" />
           </div>
-          <div className="form-header-text">
+          <div className="f137-header-text">
             <h1>Republic of the Philippines • Department of Education</h1>
             <h2>Region VII Central Visayas • Division of Bohol • District of Dauis</h2>
             <h2>LOURDES NATIONAL HIGH SCHOOL</h2>
             <h3>Dauis - Panglao Rd, Dauis, Bohol</h3>
             <h3>PERMANENT RECORD (Form 137)</h3>
           </div>
-          <div className="form-header-logos">
-            <img src="/lnhs-logo.png" alt="School Logo" className="logo" />
+          <div className="f137-header-logos">
+            <img src="/lnhs-logo.png" alt="School Logo" className="f137-logo" />
           </div>
         </div>
 
-        <div className="student-info">
-          <div className="info-item">
-            <span className="info-label">Name:</span>
+        <div className="f137-student-info">
+          <div className="f137-info-item">
+            <span className="f137-info-label">Name:</span>
             <span>{studentDetails?.stud_name || "N/A"}</span>
           </div>
-          <div className="info-item">
-            <span className="info-label">LRN:</span>
+          <div className="f137-info-item">
+            <span className="f137-info-label">LRN:</span>
             <span>{studentDetails?.student_id || "N/A"}</span>
           </div>
-          <div className="info-item">
-            <span className="info-label">Gender:</span>
+          <div className="f137-info-item">
+            <span className="f137-info-label">Gender:</span>
             <span>{studentDetails?.gender || "N/A"}</span>
           </div>
-          <div className="info-item">
-            <span className="info-label">Date of Birth:</span>
+          <div className="f137-info-item">
+            <span className="f137-info-label">Date of Birth:</span>
             <span>{studentDetails?.birthdate ? new Date(studentDetails.birthdate).toLocaleDateString() : "N/A"}</span>
           </div>
-          <div className="info-item">
-            <span className="info-label">Address:</span>
+          <div className="f137-info-item">
+            <span className="f137-info-label">Address:</span>
             <span>
               {studentDetails ? 
                 `${studentDetails.home_address || ""}, ${studentDetails.barangay || ""}, ${studentDetails.city_municipality || ""}` 
                 : "N/A"}
             </span>
           </div>
-          <div className="info-item">
-            <span className="info-label">Parent/Guardian:</span>
+          <div className="f137-info-item">
+            <span className="f137-info-label">Parent/Guardian:</span>
             <span>
               {studentDetails ? 
                 `${studentDetails.father_name || "N/A"} / ${studentDetails.mother_name || "N/A"}` 
@@ -243,25 +243,25 @@ function Form137() {
           </div>
         </div>
 
-        <div className="academic-records">
+        <div className="f137-academic-records">
           {academicRecords.map((record, index) => (
-            <div key={index} className="school-year-section">
-              <div className="school-year-header">
+            <div key={index} className="f137-school-year-section">
+              <div className="f137-school-year-header">
                 <div>
-                  <span className="info-label">SY:</span>
+                  <span className="f137-info-label">SY:</span>
                   <span>{record.schoolYear}</span>
                 </div>
                 <div>
-                  <span className="info-label">Grade:</span>
+                  <span className="f137-info-label">Grade:</span>
                   <span>{record.gradeLevel}</span>
                 </div>
                 <div>
-                  <span className="info-label">School:</span>
+                  <span className="f137-info-label">School:</span>
                   <span>{record.schoolName}</span>
                 </div>
               </div>
 
-              <table className="academic-grades-table">
+              <table className="f137-academic-grades-table">
                 <thead>
                   <tr>
                     <th style={{width: "30%"}}>Subject</th>
@@ -275,12 +275,12 @@ function Form137() {
                 <tbody>
                   {record.subjects.map((subject, subIndex) => (
                     <tr key={subIndex}>
-                      <td className="subject-name">{subject.name}</td>
+                      <td className="f137-subject-name">{subject.name}</td>
                       <td>{subject.q1}</td>
                       <td>{subject.q2}</td>
                       <td>{subject.q3}</td>
                       <td>{subject.q4}</td>
-                      <td className="final-grade">{subject.final}</td>
+                      <td className="f137-final-grade">{subject.final}</td>
                     </tr>
                   ))}
                   <tr>
@@ -291,8 +291,8 @@ function Form137() {
               </table>
 
               <div style={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
-                <div className="attendance-section" style={{width: "70%"}}>
-                  <table className="student-attendance-table">
+                <div className="f137-attendance-section" style={{width: "70%"}}>
+                  <table className="f137-student-attendance-table">
                     <thead>
                       <tr>
                         <th>Days Present</th>
@@ -309,7 +309,7 @@ function Form137() {
                     </tbody>
                   </table>
                 </div>
-                <div className="summary-section" style={{
+                <div className="f137-summary-section" style={{
                   width: "28%", 
                   display: "flex", 
                   alignItems: "center", 
@@ -318,8 +318,8 @@ function Form137() {
                   padding: "8px",
                   backgroundColor: "#f0f0f0"
                 }}>
-                  <div className="info-item" style={{margin: 0}}>
-                    <span className="info-label">Remarks:</span>
+                  <div className="f137-info-item" style={{margin: 0}}>
+                    <span className="f137-info-label">Remarks:</span>
                     <span>{record.remarks}</span>
                   </div>
                 </div>
@@ -328,26 +328,26 @@ function Form137() {
           ))}
         </div>
 
-        <div className="certification-section">
+        <div className="f137-certification-section">
           <p>
             I hereby certify that this is a true record of {studentDetails?.stud_name || "[Student Name]"}.
             This certification is issued for whatever legal purpose it may serve.
           </p>
         </div>
 
-        <div className="signature-section">
-          <div className="signature-box">
-            <div className="signature-line"></div>
+        <div className="f137-signature-section">
+          <div className="f137-signature-box">
+            <div className="f137-signature-line"></div>
             <p>Class Adviser</p>
           </div>
-          <div className="signature-box">
-            <div className="signature-line"></div>
+          <div className="f137-signature-box">
+            <div className="f137-signature-line"></div>
             <p>School Principal</p>
           </div>
         </div>
       </div>
 
-      <div className="button-container">
+      <div className="f137-button-container">
         <button onClick={handleBack}>Back</button>
         <button onClick={handleConvertToPdf}>Print</button>
       </div>

--- a/src/reports/form_138.js
+++ b/src/reports/form_138.js
@@ -107,10 +107,10 @@ function Form138() {
       format: "a4",
     });
 
-    const button = document.querySelector(".button-container");
+    const button = document.querySelector(".f138-button-container");
     if (button) button.style.display = "none";
 
-    doc.html(document.querySelector(".form-138-container"), {
+    doc.html(document.querySelector(".f138-container"), {
       callback: function (doc) {
         window.open(doc.output("bloburl"), "_blank");
         if (button) button.style.display = "flex";
@@ -136,53 +136,53 @@ function Form138() {
 
   return (
     <div>
-      <div className="form-138-container">
-        <div className="form-header">
-          <div className="form-header-logos">
-            <img src="/deped-logo.png" alt="DepEd Logo" className="logo" />
+      <div className="f138-container">
+        <div className="f138-header">
+          <div className="f138-header-logos">
+            <img src="/deped-logo.png" alt="DepEd Logo" className="f138-logo" />
           </div>
-          <div className="form-header-text">
+          <div className="f138-header-text">
             <h1>Republic of the Philippines • Department of Education</h1>
             <h2>Region VII Central Visayas • Division of Bohol • District of Dauis</h2>
             <h2>LOURDES NATIONAL HIGH SCHOOL</h2>
             <h3>Dauis - Panglao Rd, Dauis, Bohol</h3>
             <h3>REPORT CARD (Form 138)</h3>
           </div>
-          <div className="form-header-logos">
-            <img src="/lnhs-logo.png" alt="School Logo" className="logo" />
+          <div className="f138-header-logos">
+            <img src="/lnhs-logo.png" alt="School Logo" className="f138-logo" />
           </div>
         </div>
 
-        <div className="student-info">
-          <div className="info-item">
-            <span className="info-label">Name:</span>
+        <div className="f138-student-info">
+          <div className="f138-info-item">
+            <span className="f138-info-label">Name:</span>
             <span>{studentDetails?.stud_name || "N/A"}</span>
           </div>
-          <div className="info-item">
-            <span className="info-label">LRN:</span>
+          <div className="f138-info-item">
+            <span className="f138-info-label">LRN:</span>
             <span>{studentDetails?.student_id || "N/A"}</span>
           </div>
-          <div className="info-item">
-            <span className="info-label">Grade & Section:</span>
+          <div className="f138-info-item">
+            <span className="f138-info-label">Grade & Section:</span>
             <span>{currentGrades?.gradeLevel || "N/A"} - {currentGrades?.section || "N/A"}</span>
           </div>
-          <div className="info-item">
-            <span className="info-label">School Year:</span>
+          <div className="f138-info-item">
+            <span className="f138-info-label">School Year:</span>
             <span>{currentGrades?.schoolYear || currentSchoolYear || "N/A"}</span>
           </div>
-          <div className="info-item">
-            <span className="info-label">Age:</span>
+          <div className="f138-info-item">
+            <span className="f138-info-label">Age:</span>
             <span>{studentDetails?.age || "N/A"}</span>
           </div>
-          <div className="info-item">
-            <span className="info-label">Gender:</span>
+          <div className="f138-info-item">
+            <span className="f138-info-label">Gender:</span>
             <span>{studentDetails?.gender || "N/A"}</span>
           </div>
         </div>
 
-        <div className="grades-section">
+        <div className="f138-grades-section">
           <h3>Academic Performance</h3>
-          <table className="academic-grades-table">
+          <table className="f138-academic-grades-table">
             <thead>
               <tr>
                 <th style={{width: "30%"}}>Subject</th>
@@ -197,26 +197,26 @@ function Form138() {
             <tbody>
               {currentGrades?.subjects.map((subject, index) => (
                 <tr key={index}>
-                  <td className="subject-name">{subject.name}</td>
+                  <td className="f138-subject-name">{subject.name}</td>
                   <td>{subject.q1}</td>
                   <td>{subject.q2}</td>
                   <td>{subject.q3}</td>
                   <td>{subject.q4}</td>
-                  <td className="final-grade">{subject.final}</td>
+                  <td className="f138-final-grade">{subject.final}</td>
                   <td>{parseInt(subject.final) >= 75 ? "Passed" : "Failed"}</td>
                 </tr>
               ))}
               <tr>
-                <td colSpan="5" className="subject-name">General Average</td>
-                <td className="final-grade">{currentGrades?.generalAverage || "N/A"}</td>
+                <td colSpan="5" className="f138-subject-name">General Average</td>
+                <td className="f138-final-grade">{currentGrades?.generalAverage || "N/A"}</td>
                 <td>{parseInt(currentGrades?.generalAverage || 0) >= 75 ? "Passed" : "Failed"}</td>
               </tr>
             </tbody>
           </table>
         </div>
 
-        <div className="attendance-section">
-          <table className="student-attendance-table">
+        <div className="f138-attendance-section">
+          <table className="f138-student-attendance-table">
             <thead>
               <tr>
                 <th colSpan="13">Attendance Record</th>
@@ -272,26 +272,26 @@ function Form138() {
           </table>
         </div>
 
-        <div className="promotion-section">
+        <div className="f138-promotion-section">
           <h3>Promotion Status</h3>
           <p>
             <strong>Remarks:</strong> {currentGrades?.remarks || "N/A"}
           </p>
         </div>
 
-        <div className="signature-section">
-          <div className="signature-box">
-            <div className="signature-line"></div>
+        <div className="f138-signature-section">
+          <div className="f138-signature-box">
+            <div className="f138-signature-line"></div>
             <p>Class Adviser</p>
           </div>
-          <div className="signature-box">
-            <div className="signature-line"></div>
+          <div className="f138-signature-box">
+            <div className="f138-signature-line"></div>
             <p>School Principal</p>
           </div>
         </div>
       </div>
 
-      <div className="button-container">
+      <div className="f138-button-container">
         <button onClick={handleBack}>Back</button>
         <button onClick={handleConvertToPdf}>Print</button>
       </div>


### PR DESCRIPTION
- Update CSS class names with 'f137-' and 'f138-' prefixes for improved consistency
- Modify all CSS selectors and React component class names to match new naming convention
- Ensure uniform styling across Form 137 and Form 138 components
- Improve code readability and maintainability through standardized class naming