### PR TITLE
Adjust Font Sizes and Remove Default Font Family in Attendance and Br…

### DIFF
--- a/src/CssPage/Principal_AttendancePage.css
+++ b/src/CssPage/Principal_AttendancePage.css
@@ -128,6 +128,7 @@
   vertical-align: middle;
   line-height: 1.5;
   height: 48px;
+  font-size: 12px;
 }
 
 /* Set specific widths for each column */

--- a/src/RegistrarPagesCss/Registrar_BrigadaEskwela.css
+++ b/src/RegistrarPagesCss/Registrar_BrigadaEskwela.css
@@ -1,7 +1,6 @@
 /* General container styling */
 .attendance-container {
     margin: 20px;
-    font-family: Arial, sans-serif;
   }
   
   /* Title styling */


### PR DESCRIPTION
…igada Eskwela CSS

- Reduce font size to 12px in Principal Attendance Page table cells
- Remove default Arial font family from Registrar Brigada Eskwela attendance container
- Fine-tune CSS styling for improved readability and consistency