### PR TITLE
Update GradesManagement to Reset Grades Fetch State

### DIFF
--- a/src/TeacherPages/GradesManagement.js
+++ b/src/TeacherPages/GradesManagement.js
@@ -116,6 +116,7 @@ function GradesManagement() {
 
     setSelectedStudent(student);
     setEditingStudent(null);
+    setGradesFetched(false);
     const gradeLevel = student.current_yr_lvl;
     const fetchedSubjects = await fetchSubjects(student.student_id, gradeLevel);
     await fetchGrades(student.student_id, gradeLevel, fetchedSubjects);
@@ -204,13 +205,14 @@ function GradesManagement() {
 
     setSelectedStudent(student);
     setEditingStudent(student);
+    setGradesFetched(false);
     const gradeLevel = student.current_yr_lvl;
     const fetchedSubjects = await fetchSubjects(student.student_id, gradeLevel);
     await fetchGrades(student.student_id, gradeLevel, fetchedSubjects);
   };
 
   const fetchGrades = async (studentId, gradeLevel, existingSubjects) => {
-    if (!studentId || !gradeLevel || gradesFetched) return;
+    if (!studentId || !gradeLevel) return;
 
     try {
       const response = await axios.get('http://localhost:3001/api/grades', {


### PR DESCRIPTION
- Added logic to reset the gradesFetched state to false when a student is selected for editing or viewing, ensuring that grades are fetched anew for the selected student.
- Removed the gradesFetched check from the fetchGrades function to allow fetching grades regardless of the previous state.