### PR TITLE
Enhance section and grade level management features

### DIFF
--- a/src/TeacherPages/GradesManagement.js
+++ b/src/TeacherPages/GradesManagement.js
@@ -96,14 +96,27 @@ function GradesManagement() {
     }
   };
 
-  const fetchSchoolYears = async () => {
+  const fetchSchoolYears = async (studentId) => {
     try {
-      const response = await axios.get('http://localhost:3001/api/school_years');
-      setSchoolYears(response.data);
+      const response = await axios.get(`http://localhost:3001/get-grade-level/${studentId}`);
+      
+      if (response.status === 200) {
+        // Assuming response.data contains an array with { grade_level, school_year, school_year_id }
+        setSchoolYears(response.data);
+        // Optionally, set the default selectedGradeLevel to the first item in the array if it's not already set
+        if (!selectedGradeLevel && response.data.length > 0) {
+          setSelectedGradeLevel(response.data[0].grade_level); // Default to first grade level
+          setSelectedSchoolYear(response.data[0].school_year_id); // Default to first school year
+        }
+      } else {
+        console.error('Failed to fetch school years:', response.status);
+      }
     } catch (error) {
       console.error('Error fetching school years:', error);
     }
   };
+  
+  
 
   const fetchSections = async () => {
     try {
@@ -143,6 +156,7 @@ function GradesManagement() {
     // Fetch subjects and grades with the correct school year
     const fetchedSubjects = await fetchSubjects(student.student_id, gradeLevel, schoolYearId);
     await fetchGrades(student.student_id, gradeLevel, fetchedSubjects, schoolYearId);
+    await fetchSchoolYears(student.student_id); // Pass studentId here
 };
 
 
@@ -419,9 +433,6 @@ function GradesManagement() {
 };
 
 
-
-
-
   return (
     <div className="grades-management-container">
       <div className="grades-management-header">
@@ -497,9 +508,9 @@ function GradesManagement() {
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
                           <h3 className="grades-details-title">Grades for {student.firstname} {student.lastname}</h3>
                           <div className="grade-level-school-year-container">
-                            <div className="grade-level-indicator">
-                              Grade {selectedGradeLevel || student.current_yr_lvl}
-                            </div>
+                            {/* <div className="grade-level-indicator">
+                              Grade {selectedGradeLevel || student.grade_level}
+                            </div> */}
                             <select 
                               value={selectedSchoolYear || student.school_year_id} 
                               onChange={handleSchoolYearChange}
@@ -508,7 +519,7 @@ function GradesManagement() {
                             >
                               {schoolYears.map((year) => (
                                 <option key={year.school_year_id} value={year.school_year_id}>
-                                  {year.school_year}
+                                  {`Grade ${year.grade_level} - SY ${year.school_year}`}  {/* Map grade_level with school_year */}
                                 </option>
                               ))}
                             </select>

--- a/src/TeacherPages/SchoolYearManagement.js
+++ b/src/TeacherPages/SchoolYearManagement.js
@@ -58,6 +58,8 @@ function SchoolYearManagement() {
       let filtered = sortedSchoolYears;
       if (selectedFilter.school_year) {
         filtered = filtered.filter(sy => sy.school_year === selectedFilter.school_year);
+      } else {
+        filtered = filtered.filter(sy => sy.status === 'active');
       }
       
       setSchoolYears(sortedSchoolYears);

--- a/src/TeacherPages/SectionManagement.js
+++ b/src/TeacherPages/SectionManagement.js
@@ -404,6 +404,11 @@ function SectionManagement() {
                     <button
                       className="section-mgmt-btn section-mgmt-btn-archive"
                       onClick={() => toggleArchiveStatus(section.section_id, section.status)}
+                      disabled={section.hasSched === '1'}
+                      style={{
+                        opacity: section.hasSched === '1' ? 0.5 : 1,
+                        cursor: section.hasSched === '1' ? 'not-allowed' : 'pointer'
+                      }}
                     >
                       {section.status === 'inactive' ? 'Unarchive' : 'Archive'}
                     </button>

--- a/src/TeacherPages/SubjectsManagement.js
+++ b/src/TeacherPages/SubjectsManagement.js
@@ -309,11 +309,15 @@ function SubjectsManagement() {
                         {roleName === 'principal' && (
                         <button 
                         className={`subjects-management-btn ${subject?.archive_status === 'archive' ? 'subjects-management-btn-view' : 'subjects-management-btn-archive'}`}
-                          onClick={() => handleDelete(subject)}
-                          disabled={subject?.archive_status !== 'archive' && subject?.hasSched == "1"}
-                        >
-                          {subject?.archive_status === 'archive' ? 'Unarchive' : 'Archive'}
-                        </button>
+                        onClick={() => handleDelete(subject)}
+                        disabled={subject?.archive_status !== 'archive' && subject?.hasSched === "1"}
+                        style={{
+                          opacity: subject?.archive_status !== 'archive' && subject?.hasSched === "1" ? 0.5 : 1, 
+                          cursor: subject?.archive_status !== 'archive' && subject?.hasSched === "1" ? 'not-allowed' : 'pointer'
+                        }}
+                      >
+                        {subject?.archive_status === 'archive' ? 'Unarchive' : 'Archive'}
+                      </button>                    
                         )}
                       </div>
                     </td>


### PR DESCRIPTION
- Updated the '/sections' endpoint to include a 'hasSched' field indicating if a section has a schedule.
- Added a new endpoint '/get-grade-level/:student_id' to retrieve grade level and school year based on student ID.
- Modified the GradesManagement component to fetch school years based on the selected student, setting default values for grade level and school year.
- Updated the SectionManagement and SubjectsManagement components to disable archive buttons for sections and subjects that have schedules, improving user experience.