### PR TITLE
Update default section selection logic in enrollment requests

### DIFF
--- a/src/TeacherPages/EnrollmentRequests.js
+++ b/src/TeacherPages/EnrollmentRequests.js
@@ -424,10 +424,8 @@ const approveElective = async (studentElectiveId) => {
         );
         setAvailableSections(filteredSections);
         
-        // If there are available sections, set the first one as default
-        if (filteredSections.length > 0) {
-          setSelectedSection(filteredSections[0].section_id);
-        }
+        // Set to empty string for auto-assign as default
+        setSelectedSection('');
       } catch (error) {
         console.error('Error fetching sections:', error);
       }


### PR DESCRIPTION
- Changed the default selected section to an empty string for auto-assignment instead of selecting the first available section. This improves the handling of section selection during the enrollment process.