### PR TITLE
Update navigation paths in AcademicCoordinatorSideBar for consistency

### DIFF
--- a/src/RoleSidebars/AcademicCoordinatorSideBar.js
+++ b/src/RoleSidebars/AcademicCoordinatorSideBar.js
@@ -35,7 +35,7 @@ function AcademicCoordinatorSideBar({ showSidebar, toggleSidebar, handleLogout }
     setShowClassesSubMenu(!showClassesSubMenu);
     setShowExperimentalsSubMenu(false);
     if (!showClassesSubMenu) {
-      navigate('/section');
+      navigate('/schedule');
     }
   };
 
@@ -76,12 +76,12 @@ function AcademicCoordinatorSideBar({ showSidebar, toggleSidebar, handleLogout }
           </button>
           {showClassesSubMenu && (
             <div className="submenu">
-              <button 
+              {/* <button 
                 onClick={() => handleNavigate('/section')}
                 className={location.pathname === '/section' ? 'active' : ''}
               >
                 <FiBook className="icon" /> Section
-              </button>
+              </button> */}
               <button 
                 onClick={() => handleNavigate('/schedule')}
                 className={location.pathname === '/schedule' ? 'active' : ''}


### PR DESCRIPTION
- Changed navigation from '/section' to '/schedule' to align with recent updates in sidebar components.
- Commented out unused button for '/section' to streamline the interface and improve clarity.